### PR TITLE
Fixes for inherited domain class, proxy resolution issues

### DIFF
--- a/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
+++ b/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
@@ -29,7 +29,7 @@ class GrailsDomainSerializer<T> implements JsonSerializer<T> {
 			def field = ReflectionUtils.findField(instance.getClass(), property.name)
 			def value = PropertyUtils.getProperty(instance, property.name)
 			def elementName = fieldNamingStrategy.translateName(field)
-			if (!proxyHandler.isInitialized(instance, property.name)) {
+			if (proxyHandler.isProxy(value)) {
 				if (shouldResolveProxy()) {
 					log.debug "unwrapping proxy for $property.domainClass.shortName.$property.name"
 					value = proxyHandler.unwrapIfProxy(value)

--- a/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
+++ b/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
@@ -8,6 +8,7 @@ import org.apache.commons.beanutils.PropertyUtils
 import org.codehaus.groovy.grails.commons.*
 import org.codehaus.groovy.grails.commons.cfg.GrailsConfig
 import org.codehaus.groovy.grails.support.proxy.EntityProxyHandler
+import org.springframework.util.ReflectionUtils;
 
 @TupleConstructor
 @Slf4j
@@ -25,7 +26,7 @@ class GrailsDomainSerializer<T> implements JsonSerializer<T> {
 			element.add 'class', context.serialize(instance.getClass().name)
 		}
 		eachUnvisitedProperty(instance) { GrailsDomainClassProperty property ->
-			def field = instance.getClass().getDeclaredField(property.name)
+			def field = ReflectionUtils.findField(instance.getClass(), property.name)
 			def value = PropertyUtils.getProperty(instance, property.name)
 			def elementName = fieldNamingStrategy.translateName(field)
 			if (!proxyHandler.isInitialized(instance, property.name)) {

--- a/test/unit/grails/plugin/gson/serialization/AssociationWithProxyPropertySpec.groovy
+++ b/test/unit/grails/plugin/gson/serialization/AssociationWithProxyPropertySpec.groovy
@@ -1,0 +1,62 @@
+package grails.plugin.gson.serialization
+
+import com.google.gson.*
+import grails.persistence.Entity
+import grails.plugin.gson.adapters.*
+import grails.plugin.gson.spring.GsonBuilderFactory
+import grails.plugin.gson.support.proxy.DefaultEntityProxyHandler
+import grails.test.mixin.Mock
+import spock.lang.*
+
+@Mock([State, District, City])
+class AssociationWithProxyPropertySpec extends Specification{
+	Gson gson
+
+	void setupSpec() {
+		defineBeans {
+			proxyHandler DefaultEntityProxyHandler
+			domainSerializer GrailsDomainSerializer, ref('grailsApplication'), ref('proxyHandler')
+			domainDeserializer GrailsDomainDeserializer, ref('grailsApplication')
+			gsonBuilder(GsonBuilderFactory) {
+				pluginManager = ref('pluginManager')
+			}
+		}
+	}
+	
+	void setup() {
+		def gsonBuilder = applicationContext.getBean('gsonBuilder', GsonBuilder)
+		gson = gsonBuilder.create()
+	}
+	
+	def "can serialize instance"(){
+		given:
+		State state = new State(stateName: 'MyState').save(failOnError: true)
+		District district = new District(districtName: 'MyDistrict', state: state).save(failOnError: true)
+		City city = new City(cityName: 'MyCity', district: district).save(failOnError: true)
+		
+		when:
+		def json = gson.toJsonTree(city)
+		
+		then:
+		json.cityName.asString == city.cityName
+		json.district.districtName.asString == district.districtName
+		json.district.state.stateName.asString == state.stateName
+	}
+}
+
+@Entity
+class State{
+	String stateName
+}
+
+@Entity
+class District{
+	State state
+	String districtName
+}
+
+@Entity
+class City{
+	District district
+	String cityName
+}

--- a/test/unit/grails/plugin/gson/serialization/SuperclassPropertySpec.groovy
+++ b/test/unit/grails/plugin/gson/serialization/SuperclassPropertySpec.groovy
@@ -1,0 +1,92 @@
+package grails.plugin.gson.serialization
+
+import com.google.gson.*
+import grails.persistence.Entity
+import grails.plugin.gson.adapters.*
+import grails.plugin.gson.spring.GsonBuilderFactory
+import grails.plugin.gson.support.proxy.DefaultEntityProxyHandler
+import grails.test.mixin.Mock
+import spock.lang.*
+
+@Mock([SuperPerson, SuperEmployee])
+class SuperclassPropertySpec extends Specification {
+
+	Gson gson
+
+	void setupSpec() {
+		defineBeans {
+			proxyHandler DefaultEntityProxyHandler
+			domainSerializer GrailsDomainSerializer, ref('grailsApplication'), ref('proxyHandler')
+			domainDeserializer GrailsDomainDeserializer, ref('grailsApplication')
+			gsonBuilder(GsonBuilderFactory) {
+				pluginManager = ref('pluginManager')
+			}
+		}
+	}
+	
+	void setup() {
+		def gsonBuilder = applicationContext.getBean('gsonBuilder', GsonBuilder)
+		gson = gsonBuilder.create()
+	}
+	
+	def "can serialize instance of sub class"(){
+		given:
+		SuperEmployee employee = new SuperEmployee(name: 'Mark', employeeNumber: 'E1234' ).save(failOnError: true)
+		
+		when:
+		def json = gson.toJsonTree(employee)
+		
+		then:
+		json.name.asString == employee.name
+		and:
+		json.employeeNumber.asString == employee.employeeNumber
+	}
+	
+	def "can deserialize into a new instance"(){
+		given:
+		def data = [
+			name: 'Mark',
+			employeeNumber: 'E1234'
+		]
+		def json = gson.toJson(data)
+		
+		when:
+		def employee = gson.fromJson(json, SuperEmployee)
+		
+		then:
+		employee.name == data.name
+		employee.employeeNumber == data.employeeNumber
+	}
+	
+	def "can deserialize into a existing instance"(){
+		given:
+		def employee1 = new SuperEmployee(name: 'Mark', employeeNumber: 'E1234' ).save(failOnError: true)
+		and:
+		def data = [
+			id: employee1.id,
+			name: 'Mark',
+			employeeNumber: 'E1234'
+		]
+		
+		def json = gson.toJson(data)
+		
+		when:
+		def employee2 = gson.fromJson(json, SuperEmployee)
+		
+		then:
+		employee2.id == employee1.id
+		employee2.name == data.name
+		employee2.employeeNumber == data.employeeNumber
+	}
+	
+}
+
+@Entity
+class SuperPerson{
+	String name
+}
+
+@Entity
+class SuperEmployee extends SuperPerson{
+	String employeeNumber
+}


### PR DESCRIPTION
This contains fixes for the following
1. Serializing an instance of a class with inherited fields fails. This is because, in GrailsDomainSerializer, getDeclaredField() cannot get an inherited field.
2. Proxies are not resolved. In GrailsDomainSerializer,  proxyHandler.isInitialized() is used to check if the value is a proxy. However this returns true, even if value is a proxy. Instead proxyHandler.isProxy() works correctly.
   I am not quite sure how to write an unit/integration test with a hibernate proxy here. 
