### PR TITLE
New: Support for GroovyProxy's when serializing non-hibernate mapped domain class instances.

### DIFF
--- a/GsonGrailsPlugin.groovy
+++ b/GsonGrailsPlugin.groovy
@@ -3,6 +3,7 @@ import grails.plugin.gson.adapters.GrailsDomainSerializer
 import grails.plugin.gson.converters.GsonParsingParameterCreationListener
 import grails.plugin.gson.spring.GsonBuilderFactory
 import grails.plugin.gson.support.proxy.DefaultEntityProxyHandler
+import grails.plugin.gson.support.proxy.ProxyHandlerFacade
 
 class GsonGrailsPlugin {
     
@@ -29,7 +30,8 @@ class GsonGrailsPlugin {
 			proxyHandler DefaultEntityProxyHandler
 		}
 
-		domainSerializer GrailsDomainSerializer, ref('grailsApplication'), ref('proxyHandler')
+		proxyFacade ProxyHandlerFacade, ref('proxyHandler')
+		domainSerializer GrailsDomainSerializer, ref('grailsApplication'), ref('proxyFacade')
 		domainDeserializer GrailsDomainDeserializer, ref('grailsApplication')
 		gsonBuilder GsonBuilderFactory
 		jsonParsingParameterCreationListener GsonParsingParameterCreationListener, ref('gsonBuilder')

--- a/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
+++ b/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
@@ -7,7 +7,6 @@ import groovy.util.logging.Slf4j
 import org.apache.commons.beanutils.PropertyUtils
 import org.codehaus.groovy.grails.commons.*
 import org.codehaus.groovy.grails.commons.cfg.GrailsConfig
-import org.codehaus.groovy.grails.support.proxy.EntityProxyHandler
 import org.springframework.util.ReflectionUtils;
 
 @TupleConstructor
@@ -15,7 +14,7 @@ import org.springframework.util.ReflectionUtils;
 class GrailsDomainSerializer<T> implements JsonSerializer<T> {
 
 	final GrailsApplication grailsApplication
-	final EntityProxyHandler proxyHandler
+	final proxyHandler
 
 	private final Stack<GrailsDomainClassProperty> circularityStack = new Stack<GrailsDomainClassProperty>()
 

--- a/src/groovy/grails/plugin/gson/support/proxy/ProxyHandlerFacade.groovy
+++ b/src/groovy/grails/plugin/gson/support/proxy/ProxyHandlerFacade.groovy
@@ -1,0 +1,71 @@
+package grails.plugin.gson.support.proxy
+
+import groovy.transform.TupleConstructor
+import org.codehaus.groovy.grails.support.proxy.EntityProxyHandler
+import org.grails.datastore.gorm.proxy.GroovyProxyFactory
+
+/**
+ * Supports proxies for hibernate as well as mongodb mapped domain instances.
+ * As there may only be one active ProxyHandler bean defined this facade does not implement (Entity-)ProxyHandler.
+ */
+@TupleConstructor
+class ProxyHandlerFacade {
+
+	final EntityProxyHandler proxyHandler
+	
+	protected GroovyProxyFactory proxyFactory = new GroovyProxyFactory()
+
+	Object getProxyIdentifier(Object o) {
+		if (isGroovyProxy(o))
+			proxyFactory.getIdentifier o
+		else
+			proxyHandler.getProxyIdentifier o
+	}
+
+	boolean isGroovyProxy(o) {
+		o?.metaClass != null && proxyFactory.isProxy(o)
+	}
+
+	Class<?> getProxiedClass(Object o) {
+		if (isGroovyProxy(o))
+			o.class
+		else
+			proxyHandler.getProxiedClass o
+	}
+
+	boolean isProxy(Object o) {
+		isGroovyProxy(o) || proxyHandler.isProxy(o)
+	}
+
+	Object unwrapIfProxy(Object instance) {
+		if (isGroovyProxy(instance))
+			proxyFactory.unwrap instance
+		else
+			proxyHandler.unwrapIfProxy instance
+	}
+
+	boolean isInitialized(Object o) {
+		if (isGroovyProxy(o))
+			proxyFactory.isInitialized o
+		else
+			proxyHandler.isInitialized o
+	}
+
+	void initialize(Object o) {
+		if (isGroovyProxy(o))
+			o.initialize()
+		else
+			proxyHandler.initialize o
+	}
+
+	boolean isInitialized(Object obj, String associationName) {
+		if (isProxy(obj, associationName))
+			proxyFactory.isInitialized obj[associationName]
+		else
+			proxyHandler.isInitialized obj, associationName
+	}
+
+	boolean isProxy(Object obj, String associationName) {
+		obj != null && isGroovyProxy(obj[associationName])
+	}
+}

--- a/test/unit/grails/plugin/gson/support/proxy/ProxyHandlerFacadeSpec.groovy
+++ b/test/unit/grails/plugin/gson/support/proxy/ProxyHandlerFacadeSpec.groovy
@@ -1,0 +1,167 @@
+package grails.plugin.gson.support.proxy
+
+import org.codehaus.groovy.grails.support.proxy.EntityProxyHandler
+import org.grails.datastore.gorm.proxy.GroovyProxyFactory
+import spock.lang.Specification
+import spock.lang.IgnoreRest
+
+class ProxyHandlerFacadeSpec extends Specification {
+
+	ProxyHandlerFacade proxyFacade
+	EntityProxyHandler proxyHandler
+	GroovyProxyFactory proxyFactory
+
+	def setup() {
+		proxyHandler = Mock(DefaultEntityProxyHandler)
+		proxyFactory = Mock(GroovyProxyFactory)
+		proxyFacade = new ProxyHandlerFacade(proxyHandler)
+		proxyFacade.proxyFactory = proxyFactory
+	}
+
+	@IgnoreRest
+	def "facade should skip groovy proxy where metaClass is not accessible"() {
+
+		when: "calling isGroovyProxy where no metaClass is accessible"
+		def isGroovyProxy = proxyFacade.isGroovyProxy(stub)
+
+		then: "it should return false"
+		!isGroovyProxy
+
+		and: "not delegate to the groovyProxyFactory"
+		0 * proxyFactory.isProxy(_)
+
+		where:
+		stub << [null, [metaClass: null]]
+	}
+
+	def "getProxyIdentifier should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub) >> isGroovyProxy
+
+		when: "calling getProxyIdentifier"
+		proxyFacade.getProxyIdentifier(stub)
+
+		then: "the correct delegate is being used"
+		if (isGroovyProxy)
+			1 * proxyFactory.getIdentifier(stub)
+		else
+			1 * proxyHandler.getProxyIdentifier(stub)
+
+		where:
+		isGroovyProxy | stub
+		true          | new Object()
+		false         | new Object()
+	}
+
+	def "getProxiedClass should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub) >> isGroovyProxy
+
+		when: "calling getProxiedIdentifier"
+		def result = proxyFacade.getProxiedClass(stub)
+
+		then: "the correct delegate is being used"
+		result == (isGroovyProxy ? String.class : null)
+		(isGroovyProxy ? 0 : 1) * proxyHandler.getProxiedClass(stub)
+
+		where:
+		isGroovyProxy | stub
+		true          | "stub"
+		false         | "stub"
+	}
+
+	def "isProxy should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub) >> isGroovyProxy
+
+		when: "calling isProxy"
+		proxyFacade.isProxy(stub)
+
+		then: "the correct delegate is being used"
+		(isGroovyProxy ? 0 : 1) * proxyHandler.isProxy(stub)
+
+		where:
+		isGroovyProxy | stub
+		true          | "stub"
+		false         | "stub"
+	}
+
+	def "unwrapIfProxy should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub) >> isGroovyProxy
+
+		when: "calling unwrapIfProxy"
+		proxyFacade.unwrapIfProxy(stub)
+
+		then: "the correct delegate is being used"
+		if (isGroovyProxy)
+			1 * proxyFactory.unwrap(stub)
+		else
+			1 * proxyHandler.unwrapIfProxy(stub)
+
+		where:
+		isGroovyProxy | stub
+		true          | new Object()
+		false         | new Object()
+	}
+
+	def "isInitialized should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub) >> isGroovyProxy
+
+		when: "calling isInitialized"
+		proxyFacade.isInitialized(stub)
+
+		then: "the correct delegate is being used"
+		if (isGroovyProxy)
+			1 * proxyFactory.isInitialized(stub)
+		else
+			1 * proxyHandler.isInitialized(stub)
+
+		where:
+		isGroovyProxy | stub
+		true          | new Object()
+		false         | new Object()
+	}
+
+	def "initialize should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub) >> isGroovyProxy
+
+		when: "calling initialize"
+		proxyFacade.initialize(stub)
+
+		then: "the correct delegate is being used"
+		if (isGroovyProxy) stub.called
+		else 1 * proxyHandler.initialize(stub)
+
+		where:
+		isGroovyProxy | stub
+		true          | new InitializableStub()
+		false         | new Object()
+	}
+
+	def "isInitialized[association] should handle groovy proxies"() {
+		setup: "mocks"
+		1 * proxyFactory.isProxy(stub.association) >> isGroovyProxy
+
+		when: "calling isInitialized"
+		proxyFacade.isInitialized(stub, "association")
+
+		then: "the correct delegate is being used"
+		if (isGroovyProxy)
+			1 * proxyFactory.isInitialized(stub.association)
+		else
+			1 * proxyHandler.isInitialized(stub, "association")
+
+		where:
+		isGroovyProxy | stub
+		true          | [association: true]
+		false         | [association: true]
+	}
+}
+
+class InitializableStub {
+	def called = false
+	def initialize() { called = true }
+}


### PR DESCRIPTION
Hi Rob,

I came across a serialization issue when using gson with mongodb mapped instances. As the mongodb plugin uses the GroovyProxyFactory for proxies I added that support and would be happy if you'd like to merge it into upstream.

Cheers,
Patrick.
