### PR TITLE
Config option to only resolve initialized collections and proxies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,8 @@ class PersonController {
 
 By default the plugin will automatically resolve any _Hibernate_ proxies it encounters when serializing an object graph to JSON. If this is not what you want then set `grails.converters.gson.resolveProxies` to `false` in your _Config.groovy_.
 
+If you would like the plugin to resolve _Hibernate_ collections and proxy objects, but only when they have already been initialized (so no further SQL queries will be issued), set `grails.converters.gson.resolveProxies` to `false` and `grails.converters.gson.resolveInitializedProxies` to `true`.
+
 If an object graph contains bi-directional relationships they will only be traversed once (but in either direction).
 
 For example if you have the following domain classes:

--- a/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
+++ b/src/groovy/grails/plugin/gson/adapters/GrailsDomainSerializer.groovy
@@ -32,7 +32,7 @@ class GrailsDomainSerializer<T> implements JsonSerializer<T> {
 			def value = PropertyUtils.getProperty(instance, property.name)
 			def elementName = fieldNamingStrategy.translateName(field)
 			if (proxyHandler.isProxy(value)) {
-				if (shouldResolveProxy()) {
+				if (shouldResolveProxy() || (shouldResolveInitializedProxy() && proxyHandler.isInitialized(value))) {
 					log.debug "unwrapping proxy for $property.domainClass.shortName.$property.name"
 					value = proxyHandler.unwrapIfProxy(value)
 					element.add elementName, context.serialize(value, property.type)
@@ -90,6 +90,10 @@ class GrailsDomainSerializer<T> implements JsonSerializer<T> {
 
 	private boolean shouldResolveProxy() {
 		config.get('grails.converters.gson.resolveProxies', true)
+	}
+
+	private boolean shouldResolveInitializedProxy() {
+		config.get('grails.converters.gson.resolveInitializedProxies', true)
 	}
 
 	private boolean shouldOutputClass() {

--- a/test/unit/grails/plugin/gson/serialization/ProxyConfigSpec.groovy
+++ b/test/unit/grails/plugin/gson/serialization/ProxyConfigSpec.groovy
@@ -1,0 +1,97 @@
+package grails.plugin.gson.serialization
+
+import com.google.gson.GsonBuilder
+import grails.persistence.Entity
+import grails.plugin.gson.adapters.GrailsDomainDeserializer
+import grails.plugin.gson.adapters.GrailsDomainSerializer
+import grails.plugin.gson.spring.GsonBuilderFactory
+import grails.plugin.gson.support.proxy.DefaultEntityProxyHandler
+import grails.test.mixin.Mock
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Copyright Tom Dunstan 2013. All rights reserved.
+ */
+@Mock([BlogPost, Comment])
+class ProxyConfigSpec extends Specification {
+
+    def isInitialized
+
+    void setup() {
+        defineBeans {
+            proxyHandler MyEntityProxyHandler
+            domainSerializer GrailsDomainSerializer, ref('grailsApplication'), ref('proxyHandler')
+            domainDeserializer GrailsDomainDeserializer, ref('grailsApplication')
+            gsonBuilder(GsonBuilderFactory) { bean ->
+                bean.singleton = false
+                pluginManager = ref('pluginManager')
+            }
+        }
+    }
+
+    void cleanup() {
+        grailsApplication.with {
+            config.clear()
+            configChanged()
+        }
+    }
+
+    @Unroll
+    void 'output contains collection depending on config and initialized state'() {
+        given:
+            grailsApplication.with {
+                config.grails.converters.gson.resolveProxies = proxiesConfig
+                config.grails.converters.gson.resolveInitializedProxies = initializedProxiesConfig
+                configChanged()
+            }
+
+        and:
+            def gsonBuilder = applicationContext.getBean('gsonBuilder', GsonBuilder)
+            def gson = gsonBuilder.create()
+
+        and:
+            def blogPost = new BlogPost(content: 'hi there').addToComments(new Comment(content: 'you suck')).save(flush: true, failOnError: true)
+
+        and: 'collection not initialized'
+            def myEntityProxyHandler = applicationContext.getBean('proxyHandler', MyEntityProxyHandler)
+            myEntityProxyHandler.answer = isInitialized
+
+        expect:
+            gson.toJson(blogPost) == expectedOutput
+
+        where:
+            proxiesConfig | initializedProxiesConfig | isInitialized | expectedOutput
+            null          | null                     | false         | '{"id":1,"comments":[{"id":1,"content":"you suck"}],"content":"hi there"}'
+            null          | false                    | false         | '{"id":1,"comments":[{"id":1,"content":"you suck"}],"content":"hi there"}'
+            false         | false                    | false         | '{"id":1,"content":"hi there"}'
+            false         | true                     | false         | '{"id":1,"content":"hi there"}'
+            false         | false                    | true          | '{"id":1,"content":"hi there"}'
+            false         | true                     | true          | '{"id":1,"comments":[{"id":1,"content":"you suck"}],"content":"hi there"}'
+    }
+}
+
+
+@Entity
+class BlogPost {
+    String content
+    static hasMany = [comments: Comment]
+}
+
+@Entity
+class Comment {
+    String content
+    static belongsTo = [blogPost: BlogPost]
+}
+
+class MyEntityProxyHandler extends DefaultEntityProxyHandler {
+    boolean answer
+    @Override
+    public boolean isInitialized(Object o) {
+        answer
+    }
+    @Override
+    public boolean isProxy(Object o) {
+        return o instanceof Collection
+    }
+}


### PR DESCRIPTION
Allow gson domain serializer to serialize collections and other proxies if they have already been initialized, so you can start with lazy collections and initialize them manually for more fine-grained control - or specify them as eager etc in GORM config.
