### PR TITLE
Don't load associations that weren't modified.

### DIFF
--- a/src/groovy/grails/plugin/gson/adapters/GrailsDomainDeserializer.groovy
+++ b/src/groovy/grails/plugin/gson/adapters/GrailsDomainDeserializer.groovy
@@ -49,11 +49,14 @@ class GrailsDomainDeserializer<T> implements JsonDeserializer<T> {
 		}
 		bindObjectToDomainInstance domainClass, instance, properties
 
-		processBidirectionalAssociations domainClass, instance
+		def modifiedProperties = jsonEntries.collect { property ->
+			domainClass.getPersistentProperty(property.key)
+		}
+		processBidirectionalAssociations modifiedProperties, instance
 	}
 
-	private void processBidirectionalAssociations(GrailsDomainClass domainClass, T instance) {
-		domainClass.persistentProperties.each { property ->
+	private void processBidirectionalAssociations(def modifiedProperties, T instance) {
+		modifiedProperties.each { property ->
 			if (property.bidirectional) {
 				bindOwner instance."$property.name", property.otherSide, instance
 			}


### PR DESCRIPTION
The bidirectional-associations processing was always walking down all
bidirectional associations, even if they weren't modified, thereby
causing a potentially huge number of objects to be unnecessarily loaded.
This therefore explicitly only looks at those associations which are
also present in the json.

This is essentially a fix for the problem noted in https://github.com/robfletcher/grails-gson/issues/24#issuecomment-35878775
